### PR TITLE
Fix empty-byte truncation

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -369,7 +369,7 @@ func (mp *dialectMessage) encode(msg Message, isFrameV2 bool) ([]byte, error) {
 	// empty-byte truncation
 	if isFrameV2 == true {
 		end := len(buf)
-		for end > 0 && buf[end-1] == 0x00 {
+		for end > 1 && buf[end-1] == 0x00 {
 			end--
 		}
 		buf = buf[:end]


### PR DESCRIPTION
Empty-byte truncation needs to keep the last byte of the message in any case. see reference implementation: 
https://github.com/mavlink/c_library_v2/blob/master/mavlink_helpers.h#L103